### PR TITLE
Bump the min PHP version to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.0"


### PR DESCRIPTION
As you removed CI on older PHP version, telling composer that you still support them is quite risky as the CI won't catch when it is not true anymore.