### PR TITLE
CachingStream.php: Fix implicitly nullable parameter

### DIFF
--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -25,7 +25,7 @@ class CachingStream implements StreamInterface
      */
     public function __construct(
         StreamInterface $stream,
-        StreamInterface $target = null
+        ?StreamInterface $target = null
     ) {
         $this->remoteStream = $stream;
         $this->stream = $target ?: new Stream(fopen('php://temp', 'r+'));


### PR DESCRIPTION
Needed for PHP 8.4 support